### PR TITLE
Fixed: package html5lib deprecated, updated to package html

### DIFF
--- a/lib/appcache.dart
+++ b/lib/appcache.dart
@@ -2,7 +2,7 @@ library appcache;
 
 import 'package:barback/barback.dart';
 import 'dart:async' show Future;
-import 'package:html5lib/parser.dart';
+import 'package:html/parser.dart';
 
 class TransformOptions {
   List<String> entryPoints;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,6 @@ homepage: https://github.com/jrofurtado/dart-appcache
 dependencies:
   barback: '>=0.15.2+2 <0.16.0'
   code_transformers: '>=0.3.0 <0.4.0'
-  html5lib: any
+  html: any
 transformers:
 - appcache


### PR DESCRIPTION
From https://pub.dartlang.org/packages/html5lib:
Future releases of this package will happen in the html package.

To continue using html5lib without deprecation warnings, change your pubspec to depend on html5lib: '<=0.12.0'.